### PR TITLE
CVSL-2399 enabling scheduled downtime

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -18,6 +18,9 @@ generic-service:
     OS_PLACES_API_URL: "https://api.os.uk/search/places/v1"
     GOTENBERG_API_URL: "http://hmpps-assess-for-early-release-gotenberg"
 
+  scheduledDowntime:
+    enabled: true
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:


### PR DESCRIPTION
This will shut down pods between 10pm - 6:30am UTC on weekdays and all day on weekends. 6:30am was chosen as the RDS startup happens between 6am and 6:30am.