### PR TITLE
CVSL-2418 only run report job on main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,10 @@ workflows:
           password: dummy
           port: 5433
           initialise_database: "./gradlew initialiseDatabase"
+          filters:
+            branches:
+              only:
+                - main
       - validate:
           filters:
             tags:


### PR DESCRIPTION
This PR is to ensure that the database schema job is only run when a main run is happening on Circle. 