### PR TITLE
CVSL-2549 AFER | cell location and main offense are optional

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/model/AssessmentSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/model/AssessmentSummary.kt
@@ -53,9 +53,9 @@ data class AssessmentSummary(
   @Schema(description = "The opt out reason description if rhe optOutReasonType is OTHER")
   var optOutReasonOther: String? = null,
 
-  @Schema(description = "Prisoner cell location", example = "A-1-002", required = true)
-  val cellLocation: String,
+  @Schema(description = "Prisoner cell location", example = "A-1-002", required = false)
+  val cellLocation: String?,
 
-  @Schema(description = "The main offense also know as the most serious offence", example = "Robbery", required = true)
-  val mainOffense: String,
+  @Schema(description = "The main offense also know as the most serious offence", example = "Robbery", required = false)
+  val mainOffense: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/service/prison/PrisonerSearchPrisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/service/prison/PrisonerSearchPrisoner.kt
@@ -24,9 +24,9 @@ data class PrisonerSearchPrisoner(
 
   val dateOfBirth: LocalDate,
 
-  val cellLocation: String,
+  val cellLocation: String? = null,
 
-  val mostSeriousOffence: String,
+  val mostSeriousOffence: String? = null,
 
   val prisonName: String,
 )


### PR DESCRIPTION
Have made these two optional 
```
  val cellLocation: String? = null,
  val mostSeriousOffence: String? = null,
```
as they are not always there during transfer.. Also wonder if mostSeriousOffence is correct element to use :
```
 "allConvictedOffences": [
      {
        "primarySentence": true
      }
    ]
```
This fix is to allow the server side code to work while I investigate





Should have spotted this will install postman in future