### PR TITLE
CVSL-2543 AFER | Capture CRN

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/entity/Offender.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/entity/Offender.kt
@@ -43,7 +43,7 @@ data class Offender(
 
   val crd: LocalDate? = null,
 
-  val caseReferenceNumber: String? = null,
+  val crn: String? = null,
 
   val sentenceStartDate: LocalDate? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/entity/Offender.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/entity/Offender.kt
@@ -43,6 +43,8 @@ data class Offender(
 
   val crd: LocalDate? = null,
 
+  val caseReferenceNumber: String? = null,
+
   val sentenceStartDate: LocalDate? = null,
 
   @OneToMany(mappedBy = "offender", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/model/OffenderSummaryResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/model/OffenderSummaryResponse.kt
@@ -54,5 +54,5 @@ data class OffenderSummaryResponse(
   val taskOverdueOn: LocalDate? = null,
 
   @Schema(description = "The number assigned to a person on probation in NDelius ", example = "DX12340A", required = false)
-  val caseReferenceNumber: String? = null,
+  val crn: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/model/OffenderSummaryResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/model/OffenderSummaryResponse.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.hmppsassessforearlyreleaseapi.model.enum.Pos
 import java.time.LocalDate
 
 @Schema(description = "Response object which describes an offender")
-data class OffenderSummary(
+data class OffenderSummaryResponse(
   @Schema(description = "The offender's prisoner number", example = "A1234AA")
   val prisonNumber: String,
 
@@ -52,4 +52,7 @@ data class OffenderSummary(
 
   @Schema(description = "The date that the current task overdue on", example = "2028-06-23", required = false)
   val taskOverdueOn: LocalDate? = null,
+
+  @Schema(description = "The number assigned to a person on probation in NDelius ", example = "DX12340A", required = false)
+  val caseReferenceNumber: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/model/OffenderSummaryResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/model/OffenderSummaryResponse.kt
@@ -53,6 +53,6 @@ data class OffenderSummaryResponse(
   @Schema(description = "The date that the current task overdue on", example = "2028-06-23", required = false)
   val taskOverdueOn: LocalDate? = null,
 
-  @Schema(description = "The number assigned to a person on probation in NDelius ", example = "DX12340A", required = false)
+  @Schema(description = "The case reference number assigned to a person on probation in NDelius ", example = "DX12340A", required = false)
   val crn: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/resource/CaseloadResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/resource/CaseloadResource.kt
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsassessforearlyreleaseapi.config.ErrorResponse
-import uk.gov.justice.digital.hmpps.hmppsassessforearlyreleaseapi.model.OffenderSummary
+import uk.gov.justice.digital.hmpps.hmppsassessforearlyreleaseapi.model.OffenderSummaryResponse
 import uk.gov.justice.digital.hmpps.hmppsassessforearlyreleaseapi.service.OffenderService
 
 @RestController
@@ -39,7 +39,7 @@ class CaseloadResource(
         content = [
           Content(
             mediaType = "application/json",
-            array = ArraySchema(schema = Schema(implementation = OffenderSummary::class)),
+            array = ArraySchema(schema = Schema(implementation = OffenderSummaryResponse::class)),
           ),
         ],
       ),
@@ -82,7 +82,7 @@ class CaseloadResource(
         content = [
           Content(
             mediaType = "application/json",
-            array = ArraySchema(schema = Schema(implementation = OffenderSummary::class)),
+            array = ArraySchema(schema = Schema(implementation = OffenderSummaryResponse::class)),
           ),
         ],
       ),
@@ -125,7 +125,7 @@ class CaseloadResource(
         content = [
           Content(
             mediaType = "application/json",
-            array = ArraySchema(schema = Schema(implementation = OffenderSummary::class)),
+            array = ArraySchema(schema = Schema(implementation = OffenderSummaryResponse::class)),
           ),
         ],
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/service/OffenderService.kt
@@ -39,19 +39,19 @@ class OffenderService(
   @Transactional
   fun getCaseAdminCaseload(prisonCode: String): List<OffenderSummaryResponse> {
     val assessments = assessmentRepository.findByOffenderPrisonId(prisonCode)
-    return assessments.map { createOffenderSummaryResponse(it) }
+    return assessments.map { it.toOffenderSummary() }
   }
 
   @Transactional
   fun getComCaseload(staffCode: String): List<OffenderSummaryResponse> {
     val assessments = assessmentRepository.findByResponsibleComStaffCodeAndStatusIn(staffCode, getStatusesForRole(UserRole.PROBATION_COM))
-    return assessments.map { createOffenderSummaryResponse(it) }
+    return assessments.map { it.toOffenderSummary() }
   }
 
   @Transactional
   fun getDecisionMakerCaseload(prisonCode: String): List<OffenderSummaryResponse> {
     val assessments = assessmentRepository.findAllByOffenderPrisonIdAndStatusIn(prisonCode, getStatusesForRole(UserRole.PRISON_DM))
-    return assessments.map { createOffenderSummaryResponse(it) }
+    return assessments.map { it.toOffenderSummary() }
   }
 
   fun createOrUpdateOffender(nomisId: String) {
@@ -162,23 +162,22 @@ class OffenderService(
     ),
   )
 
-  private fun createOffenderSummaryResponse(assessment: Assessment): OffenderSummaryResponse = OffenderSummaryResponse(
-    prisonNumber = assessment.offender.prisonNumber,
-    bookingId = assessment.offender.bookingId,
-    forename = assessment.offender.forename!!,
-    surname = assessment.offender.surname!!,
-    hdced = assessment.offender.hdced,
-    workingDaysToHdced = workingDaysService.workingDaysBefore(assessment.offender.hdced),
-    probationPractitioner = assessment.responsibleCom?.fullName,
-    isPostponed = assessment.offender.status == AssessmentStatus.POSTPONED,
-    postponementDate = assessment.postponementDate,
-    postponementReasons = assessment.postponementReasons.map
-      { reason -> reason.reasonType }.toList(),
-    status = assessment.status,
-    addressChecksComplete = assessment.addressChecksComplete,
-    currentTask = assessment.currentTask(),
-    taskOverdueOn = assessment.offender.sentenceStartDate?.plusDays(DAYS_BEFORE_SENTENCE_START),
-    crn = assessment.offender.crn,
+  fun Assessment.toOffenderSummary() = OffenderSummaryResponse(
+    prisonNumber = offender.prisonNumber,
+    bookingId = offender.bookingId,
+    forename = offender.forename!!,
+    surname = offender.surname!!,
+    hdced = offender.hdced,
+    workingDaysToHdced = workingDaysService.workingDaysBefore(offender.hdced),
+    probationPractitioner = this.responsibleCom?.fullName,
+    isPostponed = this.status == AssessmentStatus.POSTPONED,
+    postponementDate = this.postponementDate,
+    postponementReasons = this.postponementReasons.map { reason -> reason.reasonType }.toList(),
+    status = this.status,
+    addressChecksComplete = this.addressChecksComplete,
+    currentTask = this.currentTask(),
+    taskOverdueOn = offender.sentenceStartDate?.plusDays(DAYS_BEFORE_SENTENCE_START),
+    crn = offender.crn,
   )
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/service/OffenderService.kt
@@ -74,7 +74,7 @@ class OffenderService(
   }
 
   private fun createOffender(prisoner: PrisonerSearchPrisoner) {
-    val caseReferenceNumber = probationService.getCaseReferenceNumber(prisoner.prisonerNumber)
+    val crn = probationService.getCaseReferenceNumber(prisoner.prisonerNumber)
 
     val offender = Offender(
       bookingId = prisoner.bookingId!!.toLong(),
@@ -85,15 +85,15 @@ class OffenderService(
       dateOfBirth = prisoner.dateOfBirth,
       hdced = prisoner.homeDetentionCurfewEligibilityDate!!,
       crd = prisoner.conditionalReleaseDate,
-      caseReferenceNumber = caseReferenceNumber,
+      crn = crn,
       sentenceStartDate = prisoner.sentenceStartDate,
     )
 
-    val deliusOffenderManager = caseReferenceNumber?.let {
-      probationService.getCurrentResponsibleOfficer(caseReferenceNumber)
+    val deliusOffenderManager = crn?.let {
+      probationService.getCurrentResponsibleOfficer(crn)
     }
 
-    val communityOffenderManager = caseReferenceNumber?.let {
+    val communityOffenderManager = crn?.let {
       deliusOffenderManager?.let {
         staffRepository.findByStaffCode(it.code) ?: createCommunityOffenderManager(it)
       }
@@ -178,7 +178,7 @@ class OffenderService(
     addressChecksComplete = assessment.addressChecksComplete,
     currentTask = assessment.currentTask(),
     taskOverdueOn = assessment.offender.sentenceStartDate?.plusDays(DAYS_BEFORE_SENTENCE_START),
-    caseReferenceNumber = assessment.offender.caseReferenceNumber,
+    crn = assessment.offender.crn,
   )
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/service/probation/ProbationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/service/probation/ProbationService.kt
@@ -21,7 +21,7 @@ class ProbationService(
     return deliusRecord?.otherIds?.crn
   }
 
-  fun getCurrentResponsibleOfficer(caseReferenceNumber: String): DeliusOffenderManager? = deliusApiClient.getOffenderManager(caseReferenceNumber)
+  fun getCurrentResponsibleOfficer(crn: String): DeliusOffenderManager? = deliusApiClient.getOffenderManager(crn)
 
   fun getStaffDetailsByUsername(username: String): User? {
     val staffDetails = deliusApiClient.getStaffDetailsByUsername(username)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/service/probation/ProbationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/service/probation/ProbationService.kt
@@ -15,14 +15,13 @@ class ProbationService(
   private val probationSearchApiClient: ProbationSearchApiClient,
   private val staffService: StaffService,
 ) {
-  fun getCurrentResponsibleOfficer(prisonNumber: String): DeliusOffenderManager? {
+
+  fun getCaseReferenceNumber(prisonNumber: String): String? {
     val deliusRecord = probationSearchApiClient.searchForPersonOnProbation(prisonNumber)
-    return if (deliusRecord != null) {
-      deliusApiClient.getOffenderManager(deliusRecord.otherIds.crn)
-    } else {
-      null
-    }
+    return deliusRecord?.otherIds?.crn
   }
+
+  fun getCurrentResponsibleOfficer(caseReferenceNumber: String): DeliusOffenderManager? = deliusApiClient.getOffenderManager(caseReferenceNumber)
 
   fun getStaffDetailsByUsername(username: String): User? {
     val staffDetails = deliusApiClient.getStaffDetailsByUsername(username)

--- a/src/main/resources/migration/common/V46__add_case_reference_number_to_offender.sql
+++ b/src/main/resources/migration/common/V46__add_case_reference_number_to_offender.sql
@@ -1,1 +1,1 @@
-ALTER TABLE offender ADD COLUMN case_reference_number VARCHAR(20);
+ALTER TABLE offender ADD COLUMN crn VARCHAR(20);

--- a/src/main/resources/migration/common/V46__add_case_reference_number_to_offender.sql
+++ b/src/main/resources/migration/common/V46__add_case_reference_number_to_offender.sql
@@ -1,0 +1,1 @@
+ALTER TABLE offender ADD COLUMN case_reference_number VARCHAR(20);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/integration/CaseloadResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/integration/CaseloadResourceIntTest.kt
@@ -76,7 +76,7 @@ class CaseloadResourceIntTest : SqsIntegrationTestBase() {
         .returnResult().responseBody!!
       assertThat(offenders).hasSize(4)
       assertThat(offenders.map { it.prisonNumber }).containsExactlyInAnyOrder("A1234AA", "A1234AB", "A1234AD", "C1234CD")
-      assertThat(offenders.map { it.caseReferenceNumber }).containsExactlyInAnyOrder("DX12340A", null, "DX12340D", "DX12340F")
+      assertThat(offenders.map { it.crn }).containsExactlyInAnyOrder("DX12340A", null, "DX12340D", "DX12340F")
       assertPostponeDetails(offenders, "A1234AA")
     }
   }
@@ -133,7 +133,7 @@ class CaseloadResourceIntTest : SqsIntegrationTestBase() {
         .returnResult().responseBody!!
       assertThat(offenders).hasSize(2)
       assertThat(offenders.map { it.prisonNumber }).containsExactlyInAnyOrder("A1234AB", "G9524ZF")
-      assertThat(offenders.map { it.caseReferenceNumber }).containsExactlyInAnyOrder(null, "DX12340C")
+      assertThat(offenders.map { it.crn }).containsExactlyInAnyOrder(null, "DX12340C")
       assertThat(offenders.map { it.probationPractitioner }).containsOnly("A Com")
       assertPostponeDetails(offenders, "A1234AB")
     }
@@ -193,7 +193,7 @@ class CaseloadResourceIntTest : SqsIntegrationTestBase() {
       assertThat(offenders).hasSize(2)
       assertThat(offenders.map { it.prisonNumber }).containsExactlyInAnyOrder("A1234AB", "A1234AD")
       assertThat(offenders.map { it.probationPractitioner }).containsExactlyInAnyOrder("A Com", "Another Com")
-      assertThat(offenders.map { it.caseReferenceNumber }).containsExactlyInAnyOrder("DX12340B", null)
+      assertThat(offenders.map { it.crn }).containsExactlyInAnyOrder("DX12340B", null)
 
       assertPostponeDetails(offenders, "A1234AB")
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/integration/PrisonOffenderEventListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/integration/PrisonOffenderEventListenerTest.kt
@@ -115,7 +115,7 @@ class PrisonOffenderEventListenerTest : SqsIntegrationTestBase() {
   fun `Should create a new offender `() {
     // Given
     val prisonNumber = "Z1234XY"
-    val caseReferenceNumber = "DX12340A"
+    val crn = "DX12340A"
     val hdced = LocalDate.now().plusDays(20)
     val firstName = "new first name"
     val lastName = "new last name"
@@ -138,8 +138,8 @@ class PrisonOffenderEventListenerTest : SqsIntegrationTestBase() {
         ),
       ),
     )
-    probationSearchApiMockServer.stubSearchForPersonOnProbation(caseReferenceNumber)
-    deliusMockServer.stubGetOffenderManager(caseReferenceNumber)
+    probationSearchApiMockServer.stubSearchForPersonOnProbation(crn)
+    deliusMockServer.stubGetOffenderManager(crn)
 
     val message = AdditionalInformationPrisonerUpdated(nomsNumber = prisonNumber, listOf(DiffCategory.SENTENCE))
 
@@ -163,7 +163,7 @@ class PrisonOffenderEventListenerTest : SqsIntegrationTestBase() {
     assertThat(createdOffender.surname).isEqualTo(lastName)
     assertThat(createdOffender.hdced).isEqualTo(hdced)
     assertThat(createdOffender.assessments).hasSize(1)
-    assertThat(createdOffender.caseReferenceNumber).isEqualTo(caseReferenceNumber)
+    assertThat(createdOffender.crn).isEqualTo(crn)
 
     val assessment = createdOffender.assessments.first()
     assertThat(assessment.status).isEqualTo(AssessmentStatus.NOT_STARTED)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/integration/PrisonOffenderEventListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/integration/PrisonOffenderEventListenerTest.kt
@@ -115,6 +115,7 @@ class PrisonOffenderEventListenerTest : SqsIntegrationTestBase() {
   fun `Should create a new offender `() {
     // Given
     val prisonNumber = "Z1234XY"
+    val caseReferenceNumber = "DX12340A"
     val hdced = LocalDate.now().plusDays(20)
     val firstName = "new first name"
     val lastName = "new last name"
@@ -137,8 +138,8 @@ class PrisonOffenderEventListenerTest : SqsIntegrationTestBase() {
         ),
       ),
     )
-    probationSearchApiMockServer.stubSearchForPersonOnProbation()
-    deliusMockServer.stubGetOffenderManager()
+    probationSearchApiMockServer.stubSearchForPersonOnProbation(caseReferenceNumber)
+    deliusMockServer.stubGetOffenderManager(caseReferenceNumber)
 
     val message = AdditionalInformationPrisonerUpdated(nomsNumber = prisonNumber, listOf(DiffCategory.SENTENCE))
 
@@ -162,6 +163,8 @@ class PrisonOffenderEventListenerTest : SqsIntegrationTestBase() {
     assertThat(createdOffender.surname).isEqualTo(lastName)
     assertThat(createdOffender.hdced).isEqualTo(hdced)
     assertThat(createdOffender.assessments).hasSize(1)
+    assertThat(createdOffender.caseReferenceNumber).isEqualTo(caseReferenceNumber)
+
     val assessment = createdOffender.assessments.first()
     assertThat(assessment.status).isEqualTo(AssessmentStatus.NOT_STARTED)
     assertThat(assessment.responsibleCom).isNotNull

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/integration/wiremock/DeliusMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/integration/wiremock/DeliusMockServer.kt
@@ -10,9 +10,9 @@ private const val DELIUS_WIREMOCK_PORT = 8091
 
 class DeliusMockServer : WireMockServer(DELIUS_WIREMOCK_PORT) {
 
-  fun stubGetOffenderManager(caseReferenceNumber: String = "X12345", code: String = "STAFF1") {
+  fun stubGetOffenderManager(crn: String = "X12345", code: String = "STAFF1") {
     stubFor(
-      get(urlEqualTo("/probation-case/$caseReferenceNumber/responsible-community-manager")).willReturn(
+      get(urlEqualTo("/probation-case/$crn/responsible-community-manager")).willReturn(
         aResponse().withHeader("Content-Type", "application/json").withBody(
           """{
             "id": 125,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/integration/wiremock/DeliusMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/integration/wiremock/DeliusMockServer.kt
@@ -10,9 +10,9 @@ private const val DELIUS_WIREMOCK_PORT = 8091
 
 class DeliusMockServer : WireMockServer(DELIUS_WIREMOCK_PORT) {
 
-  fun stubGetOffenderManager(crn: String = "X12345", code: String = "STAFF1") {
+  fun stubGetOffenderManager(caseReferenceNumber: String = "X12345", code: String = "STAFF1") {
     stubFor(
-      get(urlEqualTo("/probation-case/$crn/responsible-community-manager")).willReturn(
+      get(urlEqualTo("/probation-case/$caseReferenceNumber/responsible-community-manager")).willReturn(
         aResponse().withHeader("Content-Type", "application/json").withBody(
           """{
             "id": 125,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/integration/wiremock/ProbationSearchMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/integration/wiremock/ProbationSearchMockServer.kt
@@ -8,7 +8,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 private const val PROBATION_SEARCH_WIREMOCK_PORT = 8094
 
 class ProbationSearchMockServer : WireMockServer(PROBATION_SEARCH_WIREMOCK_PORT) {
-  fun stubSearchForPersonOnProbation(caseReferenceNumber: String = "X12345") {
+  fun stubSearchForPersonOnProbation(crn: String = "X12345") {
     stubFor(
       post(urlEqualTo("/search"))
         .willReturn(
@@ -19,7 +19,7 @@ class ProbationSearchMockServer : WireMockServer(PROBATION_SEARCH_WIREMOCK_PORT)
             """[
                 {
                  "offenderId": 1,
-                 "otherIds": { "crn": "$caseReferenceNumber" },
+                 "otherIds": { "crn": "$crn" },
                  "offenderManagers": [
                     {
                      "active": true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/integration/wiremock/ProbationSearchMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/integration/wiremock/ProbationSearchMockServer.kt
@@ -8,7 +8,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 private const val PROBATION_SEARCH_WIREMOCK_PORT = 8094
 
 class ProbationSearchMockServer : WireMockServer(PROBATION_SEARCH_WIREMOCK_PORT) {
-  fun stubSearchForPersonOnProbation() {
+  fun stubSearchForPersonOnProbation(caseReferenceNumber: String = "X12345") {
     stubFor(
       post(urlEqualTo("/search"))
         .willReturn(
@@ -19,7 +19,7 @@ class ProbationSearchMockServer : WireMockServer(PROBATION_SEARCH_WIREMOCK_PORT)
             """[
                 {
                  "offenderId": 1,
-                 "otherIds": { "crn": "X12345" },
+                 "otherIds": { "crn": "$caseReferenceNumber" },
                  "offenderManagers": [
                     {
                      "active": true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/service/OffenderServiceTest.kt
@@ -229,7 +229,7 @@ class OffenderServiceTest {
     val offenderCaptor = ArgumentCaptor.forClass(Offender::class.java)
     verify(offenderRepository).save(offenderCaptor.capture())
     assertThat(offenderCaptor.value)
-      .extracting("prisonNumber", "bookingId", "forename", "surname", "hdced", "caseReferenceNumber")
+      .extracting("prisonNumber", "bookingId", "forename", "surname", "hdced", "crn")
       .isEqualTo(listOf(PRISON_NUMBER, BOOKING_ID.toLong(), FORENAME, SURNAME, hdced, caseReferenceNumber))
     assertThat(offenderCaptor.value.assessments).hasSize(1)
     assertThat(offenderCaptor.value.assessments.first().policyVersion).isEqualTo(PolicyService.CURRENT_POLICY_VERSION.code)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/service/OffenderServiceTest.kt
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppsassessforearlyreleaseapi.entity.Communi
 import uk.gov.justice.digital.hmpps.hmppsassessforearlyreleaseapi.entity.Offender
 import uk.gov.justice.digital.hmpps.hmppsassessforearlyreleaseapi.entity.Task
 import uk.gov.justice.digital.hmpps.hmppsassessforearlyreleaseapi.entity.UserRole
-import uk.gov.justice.digital.hmpps.hmppsassessforearlyreleaseapi.model.OffenderSummary
+import uk.gov.justice.digital.hmpps.hmppsassessforearlyreleaseapi.model.OffenderSummaryResponse
 import uk.gov.justice.digital.hmpps.hmppsassessforearlyreleaseapi.repository.AssessmentRepository
 import uk.gov.justice.digital.hmpps.hmppsassessforearlyreleaseapi.repository.OffenderRepository
 import uk.gov.justice.digital.hmpps.hmppsassessforearlyreleaseapi.repository.StaffRepository
@@ -75,7 +75,7 @@ class OffenderServiceTest {
     val caseload = service.getCaseAdminCaseload(PRISON_ID)
     assertThat(caseload.size).isEqualTo(3)
     assertThat(caseload).containsExactlyInAnyOrder(
-      OffenderSummary(
+      OffenderSummaryResponse(
         prisonNumber = offender1.prisonNumber,
         bookingId = offender1.bookingId,
         forename = offender1.forename!!,
@@ -88,7 +88,7 @@ class OffenderServiceTest {
         currentTask = Task.ASSESS_ELIGIBILITY,
         taskOverdueOn = offender1.sentenceStartDate?.plusDays(DAYS_BEFORE_SENTENCE_START),
       ),
-      OffenderSummary(
+      OffenderSummaryResponse(
         prisonNumber = offender2.prisonNumber,
         bookingId = offender2.bookingId,
         forename = offender2.forename!!,
@@ -101,7 +101,7 @@ class OffenderServiceTest {
         currentTask = Task.ASSESS_ELIGIBILITY,
         taskOverdueOn = offender2.sentenceStartDate?.plusDays(DAYS_BEFORE_SENTENCE_START),
       ),
-      OffenderSummary(
+      OffenderSummaryResponse(
         prisonNumber = offender3.prisonNumber,
         bookingId = offender3.bookingId,
         forename = offender3.forename!!,
@@ -189,6 +189,7 @@ class OffenderServiceTest {
 
   @Test
   fun `should create a new offender and create responsible com where it doesn't already exist`() {
+    // Given
     val hdced = LocalDate.now().plusDays(23)
     val prisonerSearchPrisoner = aPrisonerSearchPrisoner(hdced = hdced)
     whenever(prisonService.searchPrisonersByNomisIds(listOf(PRISON_NUMBER))).thenReturn(
@@ -196,14 +197,18 @@ class OffenderServiceTest {
         prisonerSearchPrisoner,
       ),
     )
+    val caseReferenceNumber = "DX12340A"
+    whenever(probationService.getCaseReferenceNumber(PRISON_NUMBER)).thenReturn(caseReferenceNumber)
     val offenderManager = aDeliusOffenderManager()
-    whenever(probationService.getCurrentResponsibleOfficer(PRISON_NUMBER)).thenReturn(offenderManager)
+    whenever(probationService.getCurrentResponsibleOfficer(caseReferenceNumber)).thenReturn(offenderManager)
 
     val communityOffenderManager = aCommunityOffenderManager(offenderManager)
     whenever(staffRepository.save(any())).thenReturn(communityOffenderManager)
 
+    // When
     service.createOrUpdateOffender(PRISON_NUMBER)
 
+    // Then
     verify(prisonService).searchPrisonersByNomisIds(listOf(PRISON_NUMBER))
     verify(offenderRepository).findByPrisonNumber(PRISON_NUMBER)
 
@@ -224,8 +229,8 @@ class OffenderServiceTest {
     val offenderCaptor = ArgumentCaptor.forClass(Offender::class.java)
     verify(offenderRepository).save(offenderCaptor.capture())
     assertThat(offenderCaptor.value)
-      .extracting("prisonNumber", "bookingId", "forename", "surname", "hdced")
-      .isEqualTo(listOf(PRISON_NUMBER, BOOKING_ID.toLong(), FORENAME, SURNAME, hdced))
+      .extracting("prisonNumber", "bookingId", "forename", "surname", "hdced", "caseReferenceNumber")
+      .isEqualTo(listOf(PRISON_NUMBER, BOOKING_ID.toLong(), FORENAME, SURNAME, hdced, caseReferenceNumber))
     assertThat(offenderCaptor.value.assessments).hasSize(1)
     assertThat(offenderCaptor.value.assessments.first().policyVersion).isEqualTo(PolicyService.CURRENT_POLICY_VERSION.code)
   }

--- a/src/test/resources/test_data/com-caseload.sql
+++ b/src/test/resources/test_data/com-caseload.sql
@@ -4,14 +4,14 @@ values (1, 'STAFF1', 'a', 'com', 'a-com', 'a-com@justice.gov.uk', 'COMMUNITY_OFF
 insert into staff (id, staff_code, forename, surname, username, email, kind)
 values (2, 'STAFF2', 'another', 'com', 'another-com', 'another-com@justice.gov.uk', 'COMMUNITY_OFFENDER_MANAGER');
 
-insert into offender(booking_id, prison_number, prison_id, forename, surname, date_of_birth, hdced, crd, status)
-values (10, 'A1234AA', 'BMI', 'FIRST-1', 'LAST-1', '1978-03-20', '2020-10-25 ', '2020-11-14', 'NOT_STARTED'),
-       (20, 'A1234AB', 'BMI', 'FIRST-2', 'LAST-2', '1983-06-03', '2020-10-25', '2020-11-14', 'NOT_STARTED'),
-       (30, 'G9524ZF', 'EDF', 'FIRST-3', 'LAST-3', '1989-11-03', '2020-10-25', '2027-12-25', 'NOT_STARTED'),
-       (40, 'A1234AD', 'BMI', 'FIRST-4', 'LAST-4', '2001-12-25', '2020-10-25', '2022-03-21', 'NOT_STARTED'),
-       (50, 'C1234CC', 'MSD', 'FIRST-5', 'LAST-5', '1964-02-21', '2020-10-25', '2020-11-14', 'NOT_STARTED'),
-       (60, 'C1234CD', 'BMI', 'FIRST-6', 'LAST-6', '1987-04-18', '2020-10-25', '2023-06-01', 'NOT_STARTED'),
-       (70, 'B1234BB', 'ABC', 'FIRST-7', 'LAST-7', '1969-05-15', '2020-10-25', '2021-12-18', 'NOT_STARTED');
+insert into offender(booking_id, prison_number, prison_id, forename, surname, date_of_birth, hdced, crd, status, case_reference_number)
+values (10, 'A1234AA', 'BMI', 'FIRST-1', 'LAST-1', '1978-03-20', '2020-10-25 ', '2020-11-14', 'NOT_STARTED', 'DX12340A'),
+       (20, 'A1234AB', 'BMI', 'FIRST-2', 'LAST-2', '1983-06-03', '2020-10-25', '2020-11-14', 'NOT_STARTED', null),
+       (30, 'G9524ZF', 'EDF', 'FIRST-3', 'LAST-3', '1989-11-03', '2020-10-25', '2027-12-25', 'NOT_STARTED', 'DX12340C'),
+       (40, 'A1234AD', 'BMI', 'FIRST-4', 'LAST-4', '2001-12-25', '2020-10-25', '2022-03-21', 'NOT_STARTED', 'DX12340D'),
+       (50, 'C1234CC', 'MSD', 'FIRST-5', 'LAST-5', '1964-02-21', '2020-10-25', '2020-11-14', 'NOT_STARTED', 'DX12340E'),
+       (60, 'C1234CD', 'BMI', 'FIRST-6', 'LAST-6', '1987-04-18', '2020-10-25', '2023-06-01', 'NOT_STARTED', 'DX12340F'),
+       (70, 'B1234BB', 'ABC', 'FIRST-7', 'LAST-7', '1969-05-15', '2020-10-25', '2021-12-18', 'NOT_STARTED', 'DX12340G');
 
 insert into assessment(offender_id, status, policy_version, responsible_com_id, postponement_date)
 values ((select id from offender where booking_id = 10), 'ADDRESS_AND_RISK_CHECKS_IN_PROGRESS', '1.0', 2, null),

--- a/src/test/resources/test_data/com-caseload.sql
+++ b/src/test/resources/test_data/com-caseload.sql
@@ -4,7 +4,7 @@ values (1, 'STAFF1', 'a', 'com', 'a-com', 'a-com@justice.gov.uk', 'COMMUNITY_OFF
 insert into staff (id, staff_code, forename, surname, username, email, kind)
 values (2, 'STAFF2', 'another', 'com', 'another-com', 'another-com@justice.gov.uk', 'COMMUNITY_OFFENDER_MANAGER');
 
-insert into offender(booking_id, prison_number, prison_id, forename, surname, date_of_birth, hdced, crd, status, case_reference_number)
+insert into offender(booking_id, prison_number, prison_id, forename, surname, date_of_birth, hdced, crd, status, crn)
 values (10, 'A1234AA', 'BMI', 'FIRST-1', 'LAST-1', '1978-03-20', '2020-10-25 ', '2020-11-14', 'NOT_STARTED', 'DX12340A'),
        (20, 'A1234AB', 'BMI', 'FIRST-2', 'LAST-2', '1983-06-03', '2020-10-25', '2020-11-14', 'NOT_STARTED', null),
        (30, 'G9524ZF', 'EDF', 'FIRST-3', 'LAST-3', '1989-11-03', '2020-10-25', '2027-12-25', 'NOT_STARTED', 'DX12340C'),

--- a/src/test/resources/test_data/decision-maker-caseload.sql
+++ b/src/test/resources/test_data/decision-maker-caseload.sql
@@ -4,14 +4,14 @@ values (1, 'STAFF1', 'a', 'com', 'a-com', 'a-com@justice.gov.uk', 'COMMUNITY_OFF
 insert into staff (id, staff_code, forename, surname, username, email, kind)
 values (2, 'STAFF2', 'another', 'com', 'another-com', 'another-com@justice.gov.uk', 'COMMUNITY_OFFENDER_MANAGER');
 
-insert into offender(booking_id, prison_number, prison_id, forename, surname, date_of_birth, hdced, crd, status)
-values (10, 'A1234AA', 'BMI', 'FIRST-1', 'LAST-1', '1978-03-20', '2020-10-25 ', '2020-11-14', 'NOT_STARTED'),
-       (20, 'A1234AB', 'BMI', 'FIRST-2', 'LAST-2', '1983-06-03', '2020-10-25', '2020-11-14', 'NOT_STARTED'),
-       (30, 'G9524ZF', 'EDF', 'FIRST-3', 'LAST-3', '1989-11-03', '2020-10-25', '2027-12-25', 'NOT_STARTED'),
-       (40, 'A1234AD', 'BMI', 'FIRST-4', 'LAST-4', '2001-12-25', '2020-10-25', '2022-03-21', 'NOT_STARTED'),
-       (50, 'C1234CC', 'MSD', 'FIRST-5', 'LAST-5', '1964-02-21', '2020-10-25', '2020-11-14', 'NOT_STARTED'),
-       (60, 'C1234CD', 'BMI', 'FIRST-6', 'LAST-6', '1987-04-18', '2020-10-25', '2023-06-01', 'NOT_STARTED'),
-       (70, 'B1234BB', 'ABC', 'FIRST-7', 'LAST-7', '1969-05-15', '2020-10-25', '2021-12-18', 'NOT_STARTED');
+insert into offender(booking_id, prison_number, prison_id, forename, surname, date_of_birth, hdced, crd, status, case_reference_number)
+values (10, 'A1234AA', 'BMI', 'FIRST-1', 'LAST-1', '1978-03-20', '2020-10-25 ', '2020-11-14', 'NOT_STARTED', 'DX12340A'),
+       (20, 'A1234AB', 'BMI', 'FIRST-2', 'LAST-2', '1983-06-03', '2020-10-25', '2020-11-14', 'NOT_STARTED', 'DX12340B'),
+       (30, 'G9524ZF', 'EDF', 'FIRST-3', 'LAST-3', '1989-11-03', '2020-10-25', '2027-12-25', 'NOT_STARTED', 'DX12340C'),
+       (40, 'A1234AD', 'BMI', 'FIRST-4', 'LAST-4', '2001-12-25', '2020-10-25', '2022-03-21', 'NOT_STARTED', null),
+       (50, 'C1234CC', 'MSD', 'FIRST-5', 'LAST-5', '1964-02-21', '2020-10-25', '2020-11-14', 'NOT_STARTED', 'DX12340E'),
+       (60, 'C1234CD', 'BMI', 'FIRST-6', 'LAST-6', '1987-04-18', '2020-10-25', '2023-06-01', 'NOT_STARTED', 'DX12340F'),
+       (70, 'B1234BB', 'ABC', 'FIRST-7', 'LAST-7', '1969-05-15', '2020-10-25', '2021-12-18', 'NOT_STARTED', 'DX12340G');
 
 insert into assessment(offender_id, status, policy_version, responsible_com_id, postponement_date)
 values ((select id from offender where booking_id = 10), 'ADDRESS_AND_RISK_CHECKS_IN_PROGRESS', '1.0', 2, null),

--- a/src/test/resources/test_data/decision-maker-caseload.sql
+++ b/src/test/resources/test_data/decision-maker-caseload.sql
@@ -4,7 +4,7 @@ values (1, 'STAFF1', 'a', 'com', 'a-com', 'a-com@justice.gov.uk', 'COMMUNITY_OFF
 insert into staff (id, staff_code, forename, surname, username, email, kind)
 values (2, 'STAFF2', 'another', 'com', 'another-com', 'another-com@justice.gov.uk', 'COMMUNITY_OFFENDER_MANAGER');
 
-insert into offender(booking_id, prison_number, prison_id, forename, surname, date_of_birth, hdced, crd, status, case_reference_number)
+insert into offender(booking_id, prison_number, prison_id, forename, surname, date_of_birth, hdced, crd, status, crn)
 values (10, 'A1234AA', 'BMI', 'FIRST-1', 'LAST-1', '1978-03-20', '2020-10-25 ', '2020-11-14', 'NOT_STARTED', 'DX12340A'),
        (20, 'A1234AB', 'BMI', 'FIRST-2', 'LAST-2', '1983-06-03', '2020-10-25', '2020-11-14', 'NOT_STARTED', 'DX12340B'),
        (30, 'G9524ZF', 'EDF', 'FIRST-3', 'LAST-3', '1989-11-03', '2020-10-25', '2027-12-25', 'NOT_STARTED', 'DX12340C'),

--- a/src/test/resources/test_data/some-offenders.sql
+++ b/src/test/resources/test_data/some-offenders.sql
@@ -1,11 +1,11 @@
-insert into offender(booking_id, prison_number, prison_id, forename, surname, date_of_birth, hdced, crd, status)
-values (10, 'A1234AA', 'BMI', 'FIRST-1', 'LAST-1', '1978-03-20', current_date + 7, '2020-11-14', 'NOT_STARTED'),
-       (20, 'A1234AB', 'BMI', 'FIRST-2', 'LAST-2', '1983-06-03', current_date + 7, '2020-11-14', 'NOT_STARTED'),
-       (30, 'A1234AC', 'EDF', 'FIRST-3', 'LAST-3', '1989-11-03', current_date + 7, '2027-12-25', 'NOT_STARTED'),
-       (40, 'A1234AD', 'BMI', 'FIRST-4', 'LAST-4', '2001-12-25', current_date + 7, '2022-03-21', 'NOT_STARTED'),
-       (50, 'C1234CC', 'MSD', 'FIRST-5', 'LAST-5', '1964-02-21', current_date + 7, '2020-11-14', 'NOT_STARTED'),
-       (60, 'C1234CD', 'BMI', 'FIRST-6', 'LAST-6', '1987-04-18', current_date + 7, '2023-06-01', 'NOT_STARTED'),
-       (70, 'B1234BB', 'ABC', 'FIRST-7', 'LAST-7', '1969-05-15', current_date + 7, '2021-12-18', 'NOT_STARTED');
+insert into offender(booking_id, prison_number, prison_id, forename, surname, date_of_birth, hdced, crd, status, case_reference_number)
+values (10, 'A1234AA', 'BMI', 'FIRST-1', 'LAST-1', '1978-03-20', current_date + 7, '2020-11-14', 'NOT_STARTED', 'DX12340A'),
+       (20, 'A1234AB', 'BMI', 'FIRST-2', 'LAST-2', '1983-06-03', current_date + 7, '2020-11-14', 'NOT_STARTED', null),
+       (30, 'A1234AC', 'EDF', 'FIRST-3', 'LAST-3', '1989-11-03', current_date + 7, '2027-12-25', 'NOT_STARTED', 'DX12340C'),
+       (40, 'A1234AD', 'BMI', 'FIRST-4', 'LAST-4', '2001-12-25', current_date + 7, '2022-03-21', 'NOT_STARTED', 'DX12340D'),
+       (50, 'C1234CC', 'MSD', 'FIRST-5', 'LAST-5', '1964-02-21', current_date + 7, '2020-11-14', 'NOT_STARTED', 'DX12340E'),
+       (60, 'C1234CD', 'BMI', 'FIRST-6', 'LAST-6', '1987-04-18', current_date + 7, '2023-06-01', 'NOT_STARTED', 'DX12340F'),
+       (70, 'B1234BB', 'ABC', 'FIRST-7', 'LAST-7', '1969-05-15', current_date + 7, '2021-12-18', 'NOT_STARTED', 'DX12340G');
 
 
 insert into assessment(offender_id, status, policy_version, opt_out_reason_type, opt_out_reason_other, postponement_date)

--- a/src/test/resources/test_data/some-offenders.sql
+++ b/src/test/resources/test_data/some-offenders.sql
@@ -1,4 +1,4 @@
-insert into offender(booking_id, prison_number, prison_id, forename, surname, date_of_birth, hdced, crd, status, case_reference_number)
+insert into offender(booking_id, prison_number, prison_id, forename, surname, date_of_birth, hdced, crd, status, crn)
 values (10, 'A1234AA', 'BMI', 'FIRST-1', 'LAST-1', '1978-03-20', current_date + 7, '2020-11-14', 'NOT_STARTED', 'DX12340A'),
        (20, 'A1234AB', 'BMI', 'FIRST-2', 'LAST-2', '1983-06-03', current_date + 7, '2020-11-14', 'NOT_STARTED', null),
        (30, 'A1234AC', 'EDF', 'FIRST-3', 'LAST-3', '1989-11-03', current_date + 7, '2027-12-25', 'NOT_STARTED', 'DX12340C'),


### PR DESCRIPTION
We need to record CRN when creating an offender record 

we already retrieve it but throw away, just need to refactor 

1. Need to persist on Offender as crn
2. Expose via OffenderSummary representation
3. Handle missing connections between nomis and delius data - make CRN nullable to handle these cases. 

**I have maid caseReferenceNumber nullable for missing nomis data, please check if that will cover option 3.**