### PR TITLE
CVSL-2772: Fix JPA annotation so assessment events are saved. Remove …

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/entity/Assessment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/entity/Assessment.kt
@@ -115,7 +115,7 @@ data class Assessment(
   @OrderBy("createdTimestamp ASC")
   val postponementReasons: MutableList<PostponementReasonEntity> = mutableListOf(),
 
-  @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true)
+  @OneToOne(cascade = [CascadeType.MERGE, CascadeType.REFRESH])
   @JoinTable(
     name = "assessment_to_last_update_event",
     joinColumns =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/entity/events/AssessmentEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/entity/events/AssessmentEvent.kt
@@ -50,7 +50,7 @@ abstract class AssessmentEvent(
   val id: Long? = -1,
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "assessment_id", nullable = true)
+  @JoinColumn(name = "assessment_id", nullable = false)
   val assessment: Assessment,
 
   @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/resource/AssessmentResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/resource/AssessmentResource.kt
@@ -227,9 +227,8 @@ class AssessmentResource(
   )
   fun optBackIn(
     @Parameter(required = true) @PathVariable prisonNumber: String,
-    @Valid @RequestBody agent: AgentDto,
   ) {
-    assessmentService.optBackIn(prisonNumber, agent)
+    assessmentService.optBackIn(prisonNumber, agentHolder.getAgentOrThrow())
   }
 
   @PutMapping("/offender/{prisonNumber}/current-assessment/submit-for-address-checks")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/integration/AssessmentResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsassessforearlyreleaseapi/integration/AssessmentResourceIntTest.kt
@@ -472,8 +472,7 @@ class AssessmentResourceIntTest : SqsIntegrationTestBase() {
       // When
       val result = webTestClient.put()
         .uri(OPT_IN_ASSESSMENT_URL)
-        .headers(setAuthorisation(roles = roles))
-        .bodyValue(PRISON_CA_AGENT)
+        .headers(setAuthorisation(roles = roles, agent = PROBATION_COM_AGENT))
         .exchange()
 
       // Then


### PR DESCRIPTION
…agent parameter for opt-in endpoint as now passed via headers.